### PR TITLE
chore: release 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliff-release-workflow"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "stylelint"
 name = "Stylelint"
-version = "0.0.4"
+version = "1.0.0"
 schema_version = 1
 authors = ["Florian Sanders <sanders.florian+zed@gmail.com>"]
 description = "Language server extension providing diagnostics and auto-fix for Stylelint"


### PR DESCRIPTION
# Changelog

## [0.4.0](https://github.com/[object]/compare/0.3.0...0.4.0) (2025-06-15)


### ✅ Tests


* check (6acaf6e)


### ✨ Features


* bump cargo & extension (6b4de90)

* add b (464ddba)


### 🐛 Bug Fixes


* add tag workflow (58a05ea)

* a text (9dfad39)

* use PAT token (0d8bb12)

* add Cargo.lock (a32a8b7)

* tag release (update or create) (eba910b)

* Cargo.lock bump (74330f7)

* workflow avoid race conditions (27fdef3)

* always update prepare-release PR title (e7c5800)

* release changelog (01b2e7a)


### 👷 CI


* fix release (a7fea62)


### 🔧 Chores


* toto (69b6ca2)

